### PR TITLE
feat: update .gitignore to exclude local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 yog-test-server
 node_modules
+local.db
+.env


### PR DESCRIPTION
Add local.db and .env to .gitignore to prevent sensitive 
information and local database files from being tracked 
by Git. This enhances security and keeps the repository 
clean from environment-specific configurations.